### PR TITLE
Flush stdout when listing keys + bump verbose level for GPU count

### DIFF
--- a/source/bin/omnitrace-avail/avail.cpp
+++ b/source/bin/omnitrace-avail/avail.cpp
@@ -338,7 +338,7 @@ main(int argc, char** argv)
                                  << itr.description << "\n";
                     }
                 }
-                std::cout << _msg.str();
+                std::cout << _msg.str() << std::flush;
             }
         });
     parser
@@ -521,12 +521,12 @@ main(int argc, char** argv)
         {
             verbprintf(0, "Retrieving the GPU HW counters failed: %s", _e.what());
         }
-        verbprintf(0, "Found %i HIP devices and %zu GPU HW counters\n", gpu_count,
+        verbprintf(1, "Found %i HIP devices and %zu GPU HW counters\n", gpu_count,
                    _num_metrics);
     }
     else
     {
-        verbprintf(0, "No HIP devices found. GPU HW counters will not be available\n");
+        verbprintf(1, "No HIP devices found. GPU HW counters will not be available\n");
     }
 #endif
 

--- a/source/bin/omnitrace-avail/common.hpp
+++ b/source/bin/omnitrace-avail/common.hpp
@@ -181,18 +181,18 @@ file_exists(const std::string&);
     {                                                                                    \
         if(debug_msg || verbose_level >= LEVEL)                                          \
         {                                                                                \
-            fprintf(stdout, "%s", tim::log::color::info());                              \
-            fprintf(stdout, "[omnitrace][avail] " __VA_ARGS__);                          \
-            fprintf(stdout, "%s", tim::log::color::end());                               \
+            fprintf(stderr, "%s", tim::log::color::info());                              \
+            fprintf(stderr, "[omnitrace][avail] " __VA_ARGS__);                          \
+            fprintf(stderr, "%s", tim::log::color::end());                               \
         }                                                                                \
-        fflush(stdout);                                                                  \
+        fflush(stderr);                                                                  \
     }
 
 #define verbprintf_bare(LEVEL, ...)                                                      \
     {                                                                                    \
         if(debug_msg || verbose_level >= LEVEL)                                          \
         {                                                                                \
-            fprintf(stdout, __VA_ARGS__);                                                \
+            fprintf(stderr, __VA_ARGS__);                                                \
         }                                                                                \
-        fflush(stdout);                                                                  \
+        fflush(stderr);                                                                  \
     }

--- a/source/bin/omnitrace-avail/common.hpp
+++ b/source/bin/omnitrace-avail/common.hpp
@@ -181,18 +181,18 @@ file_exists(const std::string&);
     {                                                                                    \
         if(debug_msg || verbose_level >= LEVEL)                                          \
         {                                                                                \
-            fprintf(stderr, "%s", tim::log::color::info());                              \
-            fprintf(stderr, "[omnitrace][avail] " __VA_ARGS__);                          \
-            fprintf(stderr, "%s", tim::log::color::end());                               \
+            fprintf(stdout, "%s", tim::log::color::info());                              \
+            fprintf(stdout, "[omnitrace][avail] " __VA_ARGS__);                          \
+            fprintf(stdout, "%s", tim::log::color::end());                               \
         }                                                                                \
-        fflush(stderr);                                                                  \
+        fflush(stdout);                                                                  \
     }
 
 #define verbprintf_bare(LEVEL, ...)                                                      \
     {                                                                                    \
         if(debug_msg || verbose_level >= LEVEL)                                          \
         {                                                                                \
-            fprintf(stderr, __VA_ARGS__);                                                \
+            fprintf(stdout, __VA_ARGS__);                                                \
         }                                                                                \
-        fflush(stderr);                                                                  \
+        fflush(stdout);                                                                  \
     }


### PR DESCRIPTION
- flush stdout when listing keys to prevent overlap with stderr logging
- Report GPU device count at verbose level 1 instead of 0