### PR TITLE
Workflow, submodules, and thread info Updates

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,7 +49,7 @@ jobs:
           conda activate omnitrace-docs
           ./update-docs.sh
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./docs
 
@@ -67,4 +67,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/opensuse.yml
+++ b/.github/workflows/opensuse.yml
@@ -50,7 +50,7 @@ jobs:
 
     - name: Install Packages
       timeout-minutes: 25
-      uses: nick-fields/retry@v3
+      uses: nick-fields/retry@v2
       with:
         retry_wait_seconds: 30
         timeout_minutes: 25
@@ -127,7 +127,7 @@ jobs:
     - name: CTest Artifacts
       if: failure()
       continue-on-error: True
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: ctest-${{ github.job }}-${{ strategy.job-index }}-log
         path: |
@@ -136,7 +136,7 @@ jobs:
     - name: Data Artifacts
       if: failure()
       continue-on-error: True
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: data-${{ github.job }}-${{ strategy.job-index }}-files
         path: |

--- a/.github/workflows/opensuse.yml
+++ b/.github/workflows/opensuse.yml
@@ -50,7 +50,7 @@ jobs:
 
     - name: Install Packages
       timeout-minutes: 25
-      uses: nick-fields/retry@v2
+      uses: nick-fields/retry@v3
       with:
         retry_wait_seconds: 30
         timeout_minutes: 25
@@ -127,7 +127,7 @@ jobs:
     - name: CTest Artifacts
       if: failure()
       continue-on-error: True
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ctest-${{ github.job }}-${{ strategy.job-index }}-log
         path: |
@@ -136,7 +136,7 @@ jobs:
     - name: Data Artifacts
       if: failure()
       continue-on-error: True
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: data-${{ github.job }}-${{ strategy.job-index }}-files
         path: |

--- a/.github/workflows/ubuntu-bionic.yml
+++ b/.github/workflows/ubuntu-bionic.yml
@@ -63,7 +63,7 @@ jobs:
 
     - name: Install Packages
       timeout-minutes: 25
-      uses: nick-fields/retry@v3
+      uses: nick-fields/retry@v2
       with:
         retry_wait_seconds: 30
         timeout_minutes: 25
@@ -158,7 +158,7 @@ jobs:
     - name: CTest Artifacts
       if: failure()
       continue-on-error: True
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: ctest-${{ github.job }}-${{ strategy.job-index }}-log
         path: |
@@ -167,7 +167,7 @@ jobs:
     - name: Data Artifacts
       if: failure()
       continue-on-error: True
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: data-${{ github.job }}-${{ strategy.job-index }}-files
         path: |

--- a/.github/workflows/ubuntu-bionic.yml
+++ b/.github/workflows/ubuntu-bionic.yml
@@ -63,7 +63,7 @@ jobs:
 
     - name: Install Packages
       timeout-minutes: 25
-      uses: nick-fields/retry@v2
+      uses: nick-fields/retry@v3
       with:
         retry_wait_seconds: 30
         timeout_minutes: 25
@@ -158,7 +158,7 @@ jobs:
     - name: CTest Artifacts
       if: failure()
       continue-on-error: True
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ctest-${{ github.job }}-${{ strategy.job-index }}-log
         path: |
@@ -167,7 +167,7 @@ jobs:
     - name: Data Artifacts
       if: failure()
       continue-on-error: True
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: data-${{ github.job }}-${{ strategy.job-index }}-files
         path: |

--- a/source/bin/omnitrace-sample/impl.cpp
+++ b/source/bin/omnitrace-sample/impl.cpp
@@ -562,7 +562,7 @@ parse_args(int argc, char** argv, std::vector<char*>& _env)
     parser.add_argument({ "--profile-format" }, "Data formats for profiling results")
         .min_count(1)
         .max_count(3)
-        .requires({ "profile|flat-profile" })
+        .required({ "profile|flat-profile" })
         .choices({ "text", "json", "console" })
         .action([&](parser_t& p) {
             auto _v = p.get<std::set<std::string>>("profile");
@@ -624,7 +624,7 @@ parse_args(int argc, char** argv, std::vector<char*>& _env)
         .add_argument({ "--cpus" },
                       "CPU IDs for frequency sampling. Supports integers and/or ranges")
         .dtype("int or range")
-        .requires({ "host" })
+        .required({ "host" })
         .action([&](parser_t& p) {
             update_env(
                 _env, "OMNITRACE_SAMPLING_CPUS",
@@ -634,7 +634,7 @@ parse_args(int argc, char** argv, std::vector<char*>& _env)
         .add_argument({ "--gpus" },
                       "GPU IDs for SMI queries. Supports integers and/or ranges")
         .dtype("int or range")
-        .requires({ "device" })
+        .required({ "device" })
         .action([&](parser_t& p) {
             update_env(
                 _env, "OMNITRACE_SAMPLING_GPUS",
@@ -709,7 +709,7 @@ parse_args(int argc, char** argv, std::vector<char*>& _env)
 
     parser.add_argument({ "--realtime" }, _realtime_desc)
         .min_count(0)
-        .requires(std::move(_realtime_reqs))
+        .required(std::move(_realtime_reqs))
         .action([&](parser_t& p) {
             auto _v = p.get<std::deque<std::string>>("realtime");
             update_env(_env, "OMNITRACE_SAMPLING_REALTIME", true);

--- a/source/lib/core/argparse.cpp
+++ b/source/lib/core/argparse.cpp
@@ -870,7 +870,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .min_count(1)
             .max_count(3)
             .dtype("string")
-            .requires({ "profile|flat-profile" })
+            .required({ "profile|flat-profile" })
             .choices({ "text", "json", "console" })
             .action([&](parser_t& p) {
                 auto _v = p.get<strset_t>("profile-format");
@@ -976,7 +976,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
                 { "--cpus" },
                 "CPU IDs for frequency sampling. Supports integers and/or ranges")
             .dtype("int and/or range")
-            .requires({ "host" })
+            .required({ "host" })
             .action([&](parser_t& p) {
                 update_env(_data, "OMNITRACE_SAMPLING_CPUS",
                            join(array_config_t{ "," }, p.get<strvec_t>("cpus")));
@@ -992,7 +992,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .add_argument({ "--gpus" },
                           "GPU IDs for SMI queries. Supports integers and/or ranges")
             .dtype("int and/or range")
-            .requires({ "device" })
+            .required({ "device" })
             .action([&](parser_t& p) {
                 update_env(_data, "OMNITRACE_SAMPLING_GPUS",
                            join(array_config_t{ "," }, p.get<strvec_t>("gpus")));
@@ -1117,7 +1117,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
         _parser.add_argument({ "--sample-realtime" }, _realtime_desc)
             .min_count(0)
             .dtype("[freq] [delay] [tids...]")
-            .requires(std::move(_realtime_reqs))
+            .required(std::move(_realtime_reqs))
             .action([&](parser_t& p) {
                 auto _v = p.get<std::deque<std::string>>("sample-realtime");
                 update_env(_data, "OMNITRACE_SAMPLING_REALTIME", true);

--- a/tests/source/CMakeLists.txt
+++ b/tests/source/CMakeLists.txt
@@ -9,7 +9,7 @@ target_compile_definitions(thread-limit PRIVATE MAX_THREADS=${OMNITRACE_MAX_THRE
 target_link_libraries(thread-limit PRIVATE Threads::Threads tests-compile-options)
 
 set(_thread_limit_environment
-    "${_base_environment}" "OMNITRACE_USE_PERFETTO=ON" "OMNITRACE_USE_TIMEMORY=ON"
+    "${_base_environment}" "OMNITRACE_TRACE=ON" "OMNITRACE_PROFILE=ON"
     "OMNITRACE_COUT_OUTPUT=ON" "OMNITRACE_USE_SAMPLING=ON" "OMNITRACE_SAMPLING_FREQ=250"
     "OMNITRACE_VERBOSE=2" "OMNITRACE_TIMEMORY_COMPONENTS=wall_clock,peak_rss,page_rss")
 


### PR DESCRIPTION
- Use OMNITRACE_TRACE and OMNTRACE_PROFILE instead of perfetto/timemory
- Update timemory submodule
  - argparse: requires -> required (requires is reserved keyword in C++20)
  - parse callbacks for settings
- Update thread_info.cpp
  - fix `causal::delay::get_local()` usage which is causing error on some systems
