### PR TITLE
Executables append omnitrace library directory to LD_LIBRARY_PATH

### DIFF
--- a/source/bin/omnitrace-run/impl.cpp
+++ b/source/bin/omnitrace-run/impl.cpp
@@ -191,6 +191,7 @@ prepare_environment_for_run(parser_data_t& _data)
     if(_data.launcher.empty())
     {
         omnitrace::argparse::add_ld_preload(_data);
+        omnitrace::argparse::add_ld_library_path(_data);
     }
 }
 

--- a/source/bin/omnitrace-sample/omnitrace-sample.hpp
+++ b/source/bin/omnitrace-sample/omnitrace-sample.hpp
@@ -26,13 +26,22 @@
 #include <string_view>
 #include <vector>
 
+enum update_mode : int
+{
+    UPD_REPLACE = 0x1,
+    UPD_PREPEND = 0x2,
+    UPD_APPEND  = 0x3,
+    UPD_WEAK    = 0x4,
+};
+
 std::string
-get_realpath(const std::string&);
+get_realpath(const std::string& _fpath);
 
 void
 print_command(const std::vector<char*>& _argv);
 
-void print_updated_environment(std::vector<char*>);
+void
+print_updated_environment(std::vector<char*> _env);
 
 std::vector<char*>
 get_initial_environment();
@@ -42,10 +51,11 @@ get_internal_libpath(const std::string& _lib);
 
 template <typename Tp>
 void
-update_env(std::vector<char*>&, std::string_view, Tp&&, bool _append = false);
+update_env(std::vector<char*>& _environ, std::string_view _env_var, Tp&& _env_val,
+           update_mode&& _mode = UPD_REPLACE, std::string_view _join_delim = ":");
 
 void
-remove_env(std::vector<char*>&, std::string_view);
+remove_env(std::vector<char*>& _environ, std::string_view _env_var);
 
 std::vector<char*>
-parse_args(int argc, char** argv, std::vector<char*>&);
+parse_args(int argc, char** argv, std::vector<char*>& envp);

--- a/source/lib/core/argparse.cpp
+++ b/source/lib/core/argparse.cpp
@@ -249,6 +249,15 @@ add_ld_preload(parser_data& _data)
 }
 
 parser_data&
+add_ld_library_path(parser_data& _data)
+{
+    auto _libdir = filepath::dirname(_data.dl_libpath);
+    if(filepath::exists(_libdir))
+        update_env(_data, "LD_LIBRARY_PATH", _libdir, UPD_APPEND);
+    return _data;
+}
+
+parser_data&
 add_core_arguments(parser_t& _parser, parser_data& _data)
 {
     const auto* _cputime_desc =

--- a/source/lib/core/argparse.hpp
+++ b/source/lib/core/argparse.hpp
@@ -82,6 +82,9 @@ parser_data&
 add_ld_preload(parser_data&);
 
 parser_data&
+add_ld_library_path(parser_data&);
+
+parser_data&
 add_core_arguments(parser_t&, parser_data&);
 
 parser_data&


### PR DESCRIPTION
- `omnitrace-run`, `omnitrace-sample`, and `omnitrace-causal` now automatically append the `LD_LIBRARY_PATH` with the directory containing the omnitrace libraries
  - this helps ensure that binary rewritten exes can resolve omnitrace-rt library location

Algorithm is essentially as follows:

```console
OMNITRACE_BIN_DIR=$(dirname $(which omnitrace-run))
OMNITRACE_LIB_DIR=$(realpath ${OMNITRACE_BIN_DIR}/../lib)
export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${OMNITRACE_LIB_DIR}
```