### PR TITLE
Prepare for branch renaming. 

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -7,7 +7,7 @@ on:
   schedule:
     - cron: 0 5 * * *
   push:
-    branches: [main]
+    branches: [main, amd-mainline]
     paths:
       - '.github/workflows/containers.yml'
       - 'docker/**'

--- a/.github/workflows/cpack.yml
+++ b/.github/workflows/cpack.yml
@@ -4,7 +4,7 @@ run-name: cpack
 on:
   workflow_dispatch:
   push:
-    branches: [main, releases/**]
+    branches: [main, amd-mainline, release/**]
     tags:
       - v*
     paths-ignore:
@@ -12,7 +12,7 @@ on:
       - 'docs/**'
       - 'source/docs/**'
   pull_request:
-    branches: [main]
+    branches: [main, amd-mainline]
     paths:
       - '.github/workflows/cpack.yml'
       - 'docker/**'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,14 +3,14 @@ name: Documentation
 on:
   workflow_dispatch:
   push:
-    branches: [main, gh-pages]
+    branches: [main, amd-mainline, gh-pages]
     paths:
       - '*.md'
       - 'source/docs/**'
       - '.github/workflows/docs.yml'
       - 'VERSION'
   pull_request:
-    branches: [main]
+    branches: [main, amd-mainline]
     paths:
       - '*.md'
       - 'source/docs/**'

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -4,9 +4,9 @@ run-name: formatting
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main, develop, amd-mainline, amd-staging, release/** ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main, develop, amd-mainline, amd-staging, release/** ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/opensuse.yml
+++ b/.github/workflows/opensuse.yml
@@ -3,7 +3,7 @@ run-name: opensuse-15
 
 on:
   push:
-    branches: [ main, develop, release/** ]
+    branches: [ main, develop, amd-mainline, amd-staging, release/** ]
     paths-ignore:
       - '*.md'
       - 'docs/**'
@@ -15,7 +15,7 @@ on:
       - '.github/workflows/formatting.yml'
       - 'docker/**'
   pull_request:
-    branches: [ main, develop, release/** ]
+    branches: [ main, develop, amd-mainline, amd-staging, release/** ]
     paths-ignore:
       - '*.md'
       - 'docs/**'

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -3,12 +3,12 @@ run-name: Python
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main, develop, amd-mainline, amd-staging ]
     paths:
       - 'source/python/gui/*.py'
       - 'source/python/gui/**/*.py'
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main, develop, amd-mainline, amd-staging ]
     paths:
       - 'source/python/gui/*.py'
       - 'source/python/gui/**/*.py'

--- a/.github/workflows/redhat.yml
+++ b/.github/workflows/redhat.yml
@@ -3,7 +3,7 @@ run-name: redhat
 
 on:
   push:
-    branches: [ main, develop, release/** ]
+    branches: [ main, develop, amd-mainline, amd-staging, release/** ]
     paths-ignore:
       - '*.md'
       - 'docs/**'
@@ -15,7 +15,7 @@ on:
       - '.github/workflows/formatting.yml'
       - 'docker/**'
   pull_request:
-    branches: [ main, develop, release/** ]
+    branches: [ main, develop, amd-mainline, amd-staging, release/** ]
     paths-ignore:
       - '*.md'
       - 'docs/**'

--- a/.github/workflows/ubuntu-focal.yml
+++ b/.github/workflows/ubuntu-focal.yml
@@ -3,7 +3,7 @@ run-name: ubuntu-focal
 
 on:
   push:
-    branches: [ main, develop, release/** ]
+    branches: [ main, develop, amd-mainline, amd-staging, release/** ]
     paths-ignore:
       - '*.md'
       - 'docs/**'
@@ -15,7 +15,7 @@ on:
       - '.github/workflows/formatting.yml'
       - 'docker/**'
   pull_request:
-    branches: [ main, develop, release/** ]
+    branches: [ main, develop, amd-mainline, amd-staging, release/** ]
     paths-ignore:
       - '*.md'
       - 'docs/**'

--- a/.github/workflows/ubuntu-jammy.yml
+++ b/.github/workflows/ubuntu-jammy.yml
@@ -3,7 +3,7 @@ run-name: ubuntu-jammy
 
 on:
   push:
-    branches: [ main, develop, release/** ]
+    branches: [ main, develop, amd-mainline, amd-staging, release/** ]
     paths-ignore:
       - '*.md'
       - 'docs/**'
@@ -15,7 +15,7 @@ on:
       - '.github/workflows/formatting.yml'
       - 'docker/**'
   pull_request:
-    branches: [ main, develop, release/** ]
+    branches: [ main, develop, amd-mainline, amd-staging, release/** ]
     paths-ignore:
       - '*.md'
       - 'docs/**'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,7 +30,7 @@ The documentation is structured as follows:
 
   .. grid-item-card:: Tutorials
 
-    * `GitHub examples <https://github.com/ROCm/omnitrace/tree/main/examples>`_
+    * `GitHub examples <https://github.com/ROCm/omnitrace/tree/amd-mainline/examples>`_
     * :doc:`Video tutorials <./tutorials/video-tutorials>`
 
   .. grid-item-card:: How to

--- a/docs/reference/development-guide.rst
+++ b/docs/reference/development-guide.rst
@@ -15,7 +15,7 @@ Executables
 
 This section lists the Omnitrace executables.
 
-omnitrace-avail: `source/bin/omnitrace-avail <https://github.com/ROCm/omnitrace/tree/main/source/bin/omnitrace-avail>`_
+omnitrace-avail: `source/bin/omnitrace-avail <https://github.com/ROCm/omnitrace/tree/amd-mainline/source/bin/omnitrace-avail>`_
 -------------------------------------------------------------------------------------------------------------------------------
 
 The ``main`` routine of ``omnitrace-avail`` has three important sections:
@@ -24,7 +24,7 @@ The ``main`` routine of ``omnitrace-avail`` has three important sections:
 * Printing options
 * Printing hardware counters
 
-omnitrace-sample: `source/bin/omnitrace-sample <https://github.com/ROCm/omnitrace/tree/main/source/bin/omnitrace-sample>`_
+omnitrace-sample: `source/bin/omnitrace-sample <https://github.com/ROCm/omnitrace/tree/amd-mainline/source/bin/omnitrace-sample>`_
 -------------------------------------------------------------------------------------------------------------------------------
 
 * Requires a command-line format of ``omnitrace-sample <options> -- <command> <command-args>``
@@ -32,7 +32,7 @@ omnitrace-sample: `source/bin/omnitrace-sample <https://github.com/ROCm/omnitrac
 * Adds ``libomnitrace-dl.so`` to ``LD_PRELOAD``
 * Is launched by using ``execvpe`` with ``<command> <command-args>`` and a modified environment
 
-omnitrace-casual: `source/bin/omnitrace-causal <https://github.com/ROCm/omnitrace/tree/main/source/bin/omnitrace-causal>`_
+omnitrace-casual: `source/bin/omnitrace-causal <https://github.com/ROCm/omnitrace/tree/amd-mainline/source/bin/omnitrace-causal>`_
 -------------------------------------------------------------------------------------------------------------------------------
 
 When there is exactly one causal profiling configuration variant (which enables debugging),
@@ -45,7 +45,7 @@ the following actions take place for each variant:
 * the child process launches ``<command> <command-args>`` using ``execvpe``, which modifies the environment for the variant
 * the parent process waits for the child process to finish
 
-omnitrace-instrument: `source/bin/omnitrace-instrument <https://github.com/ROCm/omnitrace/tree/main/source/bin/omnitrace-instrument>`_
+omnitrace-instrument: `source/bin/omnitrace-instrument <https://github.com/ROCm/omnitrace/tree/amd-mainline/source/bin/omnitrace-instrument>`_
 -------------------------------------------------------------------------------------------------------------------------------------------
 
 * Requires a command-line format of ``omnitrace-instrument <options> -- <command> <command-args>``
@@ -70,31 +70,31 @@ omnitrace-instrument: `source/bin/omnitrace-instrument <https://github.com/ROCm/
 Libraries
 ========================================
 
-Common library: `source/lib/common <https://github.com/ROCm/omnitrace/tree/main/source/lib/common>`_
+Common library: `source/lib/common <https://github.com/ROCm/omnitrace/tree/amd-mainline/source/lib/common>`_
 --------------------------------------------------------------------------------------------------------------------------------
 
 * General header-only functionality used in multiple executables and/or libraries. 
 * Not installed or exported outside of the build tree.
 
-Core library: `source/lib/core <https://github.com/ROCm/omnitrace/tree/main/source/lib/core>`_
+Core library: `source/lib/core <https://github.com/ROCm/omnitrace/tree/amd-mainline/source/lib/core>`_
 --------------------------------------------------------------------------------------------------------------------------------
 
 * Static PIC library with functionality that does not depend on any components. 
 * Not installed or exported outside of the build tree.
 
-Binary library: `source/lib/binary <https://github.com/ROCm/omnitrace/tree/main/source/lib/binary>`_
+Binary library: `source/lib/binary <https://github.com/ROCm/omnitrace/tree/amd-mainline/source/lib/binary>`_
 --------------------------------------------------------------------------------------------------------------------------------
 
 * Static PIC library with functionality for reading/analyzing binary info.
 * Mostly used by the causal profiling sections of ``libomnitrace``.
 * Not installed or exported outside of the build tree.
 
-libomnitrace: `source/lib/omnitrace <https://github.com/ROCm/omnitrace/tree/main/source/lib/omnitrace>`_
+libomnitrace: `source/lib/omnitrace <https://github.com/ROCm/omnitrace/tree/amd-mainline/source/lib/omnitrace>`_
 --------------------------------------------------------------------------------------------------------------------------------
 
 This is the main library encapsulating all the capabilities.
 
-libomnitrace-dl: `source/lib/omnitrace-dl <https://github.com/ROCm/omnitrace/tree/main/source/lib/omnitrace-dl>`_
+libomnitrace-dl: `source/lib/omnitrace-dl <https://github.com/ROCm/omnitrace/tree/amd-mainline/source/lib/omnitrace-dl>`_
 --------------------------------------------------------------------------------------------------------------------------------
 
 This is a lightweight, front-end library for ``libomnitrace`` which serves three primary purposes:
@@ -105,7 +105,7 @@ This is a lightweight, front-end library for ``libomnitrace`` which serves three
 * Prevents re-entry if ``libomnitrace`` calls an instrumented function internally
 * Coordinates communication between ``libomnitrace-user`` and ``libomnitrace``
 
-libomnitrace-user: `source/lib/omnitrace-user <https://github.com/ROCm/omnitrace/tree/main/source/lib/omnitrace-user>`_
+libomnitrace-user: `source/lib/omnitrace-user <https://github.com/ROCm/omnitrace/tree/amd-mainline/source/lib/omnitrace-user>`_
 --------------------------------------------------------------------------------------------------------------------------------
 
 * Provides a set of functions and types for the users to add to their code, for example,

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -17,7 +17,7 @@ subtrees:
 
   - caption: Tutorials
     entries:
-    - url: https://github.com/ROCm/omnitrace/tree/main/examples
+    - url: https://github.com/ROCm/omnitrace/tree/amd-mainline/examples
       title: GitHub examples
     - file: tutorials/video-tutorials.rst
       title: Video tutorials

--- a/source/docs/development.md
+++ b/source/docs/development.md
@@ -7,7 +7,7 @@
 
 ## Executables
 
-### omnitrace-avail: [source/bin/omnitrace-avail](https://github.com/ROCm/omnitrace/tree/main/source/bin/omnitrace-avail)
+### omnitrace-avail: [source/bin/omnitrace-avail](https://github.com/ROCm/omnitrace/tree/amd-mainline/source/bin/omnitrace-avail)
 
 The main of `omnitrace-avail` has three important sections:
 
@@ -15,7 +15,7 @@ The main of `omnitrace-avail` has three important sections:
 2. Printing options
 3. Printing hardware counters
 
-### omnitrace-sample: [source/bin/omnitrace-sample](https://github.com/ROCm/omnitrace/tree/main/source/bin/omnitrace-sample)
+### omnitrace-sample: [source/bin/omnitrace-sample](https://github.com/ROCm/omnitrace/tree/amd-mainline/source/bin/omnitrace-sample)
 
 General design:
 
@@ -24,7 +24,7 @@ General design:
 - Adds `libomnitrace-dl.so` to `LD_PRELOAD`
 - Application is launched via `execvpe` with `<command> <command-args>` and modified environment
 
-### omnitrace-casual: [source/bin/omnitrace-causal](https://github.com/ROCm/omnitrace/tree/main/source/bin/omnitrace-causal)
+### omnitrace-casual: [source/bin/omnitrace-causal](https://github.com/ROCm/omnitrace/tree/amd-mainline/source/bin/omnitrace-causal)
 
 Nearly identical design to [omnitrace-sample](#omnitrace-sample-sourcebinomnitrace-sample) when
 there is exactly one causal profiling configuration variant (this enables debugging).
@@ -36,7 +36,7 @@ for each variant:
 - child process launches `<command> <command-args>` via `execvpe` which modified environment for variant
 - parent process waits for child process to finish
 
-### omnitrace-instrument: [source/bin/omnitrace-instrument](https://github.com/ROCm/omnitrace/tree/main/source/bin/omnitrace-instrument)
+### omnitrace-instrument: [source/bin/omnitrace-instrument](https://github.com/ROCm/omnitrace/tree/amd-mainline/source/bin/omnitrace-instrument)
 
 - Requires a command-line format of `omnitrace-instrument <options> -- <command> <command-args>`
 - User specifies in options whether they want to do runtime instrumentation, binary rewrite, or attach to process
@@ -52,24 +52,24 @@ for each variant:
 
 ## Libraries
 
-### Common Library: [source/lib/common](https://github.com/ROCm/omnitrace/tree/main/source/lib/common)
+### Common Library: [source/lib/common](https://github.com/ROCm/omnitrace/tree/amd-mainline/source/lib/common)
 
 General header-only functionality used in multiple executables and/or libraries. Not installed or exported outside of the build tree.
 
-### Core Library: [source/lib/core](https://github.com/ROCm/omnitrace/tree/main/source/lib/core)
+### Core Library: [source/lib/core](https://github.com/ROCm/omnitrace/tree/amd-mainline/source/lib/core)
 
 Static PIC library with functionality that does not depend on any components. Not installed or exported outside of the build tree.
 
-### Binary Library: [source/lib/binary](https://github.com/ROCm/omnitrace/tree/main/source/lib/binary)
+### Binary Library: [source/lib/binary](https://github.com/ROCm/omnitrace/tree/amd-mainline/source/lib/binary)
 
 Static PIC library with functionality for reading/analyzing binary info. Mostly used by the causal profiling sections
 of [libomnitrace](#libomnitrace-sourcelibomnitrace). Not installed or exported outside of the build tree.
 
-### libomnitrace: [source/lib/omnitrace](https://github.com/ROCm/omnitrace/tree/main/source/lib/omnitrace)
+### libomnitrace: [source/lib/omnitrace](https://github.com/ROCm/omnitrace/tree/amd-mainline/source/lib/omnitrace)
 
 This is the main library encapsulating all the capabilities.
 
-### libomnitrace-dl: [source/lib/omnitrace-dl](https://github.com/ROCm/omnitrace/tree/main/source/lib/omnitrace-dl)
+### libomnitrace-dl: [source/lib/omnitrace-dl](https://github.com/ROCm/omnitrace/tree/amd-mainline/source/lib/omnitrace-dl)
 
 Lightweight, front-end library for [libomnitrace](#libomnitrace-sourcelibomnitrace) which serves 3 primary purposes:
 
@@ -77,7 +77,7 @@ Lightweight, front-end library for [libomnitrace](#libomnitrace-sourcelibomnitra
 2. Prevents re-entry if [libomnitrace](#libomnitrace-sourcelibomnitrace) calls an instrumentated function internally)
 3. Coordinates communication between [libomnitrace-user](#libomnitrace-user-sourcelibomnitrace-user) and [libomnitrace](#libomnitrace-sourcelibomnitrace)
 
-### libomnitrace-user: [source/lib/omnitrace-user](https://github.com/ROCm/omnitrace/tree/main/source/lib/omnitrace-user)
+### libomnitrace-user: [source/lib/omnitrace-user](https://github.com/ROCm/omnitrace/tree/amd-mainline/source/lib/omnitrace-user)
 
 Provides a set of functions and types for the users to add to their code, e.g. disabling data collection globally or on a specific thread,
 user-defined regions, etc. If [libomnitrace-dl](#libomnitrace-dl-sourcelibomnitrace-dl) is not loaded, the user API is effectively no-op


### PR DESCRIPTION
There is a Dev-Ops request to use standard branch names for our staging and main branches. This change is prep work for that.

main --> amd-mainline
Will create amd-staging.

New branch names have been added to workflows. However, old branch names will not be removed until renaming is complete.