### PR TITLE
Fix SWDEV-473314 by avoiding empty unique_ptr dereference

### DIFF
--- a/source/lib/omnitrace/library/components/roctracer.cpp
+++ b/source/lib/omnitrace/library/components/roctracer.cpp
@@ -314,12 +314,7 @@ void
 roctracer::shutdown()
 {
     auto_lock_t _lk{ type_mutex<roctracer>() };
-    if(!roctracer_is_setup())
-    {
-        if(!roctracer_is_init() && tim::storage<comp::roctracer_data>::instance())
-            tim::storage<comp::roctracer_data>::instance()->reset();
-        return;
-    }
+    if(!roctracer_is_setup()) return;
 
     roctracer_is_setup() = false;
 


### PR DESCRIPTION
- Revert part of [blamed commit](https://github.com/ROCm/omnitrace/pull/78/commits/b134a68110b2c96ce11293d93ad56f38e211fd06) modifying source/lib/omnitrace/library/components/roctracer.cpp with goal of  "clear roctracer_data storage if roctracer not initialized"
- Particularly, I don't think ```tim::storage<comp::roctracer_data>::instance()``` returns the instance of the storage singleton if it exists, but rather creates an empty unique_ptr to the storage type